### PR TITLE
fix: post table of contents scoping

### DIFF
--- a/src/components/posts/post-content.tsx
+++ b/src/components/posts/post-content.tsx
@@ -30,7 +30,10 @@ export default async function PostContent({ slug }: { slug: string }) {
   return (
     <div className="flex flex-row justify-center gap-10 lg:justify-normal">
       <div className="relative grow overflow-hidden">
-        <article className="markdown-body mt-4 rounded-2xl bg-primary-bg px-4 py-5 shadow-cxs md:px-8 md:py-10">
+        <article
+          className="markdown-body mt-4 rounded-2xl bg-primary-bg px-4 py-5 shadow-cxs md:px-8 md:py-10"
+          data-toc-root={decodedSlug}
+        >
           <header className="mb-4 md:mb-5">
             <h1
               className={`relative text-2xl font-bold leading-tight before:absolute before:-left-2 before:top-1.5 before:h-5 before:w-1 before:rounded-md before:bg-primary-medium md:text-4xl md:before:-left-3 md:before:top-2 md:before:h-6`}
@@ -60,7 +63,7 @@ export default async function PostContent({ slug }: { slug: string }) {
       <aside className="sticky top-20 hidden h-max max-h-[calc(-80px+100vh)] w-56 shrink-0 overflow-auto p-2 lg:block lg:gap-4">
         <nav className="flex flex-col gap-2">
           <h2 className="w-max text-2xl font-medium tracking-wider text-primary">目录</h2>
-          <TableOfContents />
+          <TableOfContents rootKey={decodedSlug} />
         </nav>
       </aside>
     </div>

--- a/src/components/posts/table-of-contents.tsx
+++ b/src/components/posts/table-of-contents.tsx
@@ -10,12 +10,22 @@ interface Heading {
 
 type Headings = Heading[]
 
-const headingSelector = 'article.markdown-body :is(h2, h3, h4, h5, h6)[id]'
+const headingSelector = ':is(h2, h3, h4, h5, h6)[id]'
 
-function collectHeadings(): Headings {
+function findTocRoot(rootKey: string) {
+  return Array.from(document.querySelectorAll('article.markdown-body[data-toc-root]')).find(
+    (element): element is HTMLElement =>
+      element instanceof HTMLElement && element.dataset.tocRoot === rootKey,
+  )
+}
+
+function collectHeadings(rootKey: string): Headings {
+  const root = findTocRoot(rootKey)
+  if (!root) return []
+
   const usedIds = new Set<string>()
 
-  return Array.from(document.querySelectorAll(headingSelector))
+  return Array.from(root.querySelectorAll(headingSelector))
     .filter((element): element is HTMLElement => element instanceof HTMLElement)
     .reduce<Headings>((items, element) => {
       const id = element.id.trim()
@@ -36,15 +46,15 @@ function collectHeadings(): Headings {
     }, [])
 }
 
-function useHeadings() {
+function useHeadings(rootKey: string) {
   const [headings, setHeadings] = useState<Headings>([])
 
   useEffect(() => {
-    const updateHeadings = () => setHeadings(collectHeadings())
+    const updateHeadings = () => setHeadings(collectHeadings(rootKey))
 
     updateHeadings()
 
-    const markdownBody = document.querySelector('article.markdown-body')
+    const markdownBody = findTocRoot(rootKey)
     if (!markdownBody) return undefined
 
     const observer = new MutationObserver(updateHeadings)
@@ -56,25 +66,37 @@ function useHeadings() {
     })
 
     return () => observer.disconnect()
-  }, [])
+  }, [rootKey])
   return headings
 }
 
-function useScrollSpy(headings: Headings) {
+function useScrollSpy(headings: Headings, rootKey: string) {
   const [activeId, setActiveId] = useState<string>()
 
   useEffect(() => {
-    const elements = headings
-      .map(({ id }) => document.getElementById(id))
-      .filter((element): element is HTMLElement => element instanceof HTMLElement)
+    const root = findTocRoot(rootKey)
+    const elements = root
+      ? headings
+          .map(({ id }) =>
+            Array.from(root.querySelectorAll('[id]')).find(
+              (element): element is HTMLElement =>
+                element instanceof HTMLElement && element.id === id,
+            ),
+          )
+          .filter((element): element is HTMLElement => element instanceof HTMLElement)
+      : []
+
+    let frame: number | undefined
 
     if (elements.length === 0) {
-      setActiveId(undefined)
-      return undefined
+      const emptyFrame = window.requestAnimationFrame(() => {
+        setActiveId(undefined)
+      })
+
+      return () => window.cancelAnimationFrame(emptyFrame)
     }
 
     const offset = 112
-    let frame: number | undefined
 
     const updateActiveHeading = () => {
       let currentId = ''
@@ -116,14 +138,14 @@ function useScrollSpy(headings: Headings) {
       window.removeEventListener('scroll', scheduleUpdate)
       window.removeEventListener('resize', scheduleUpdate)
     }
-  }, [headings])
+  }, [headings, rootKey])
 
   return activeId
 }
 
-const TableOfContents: React.FC = () => {
-  const headings = useHeadings()
-  const activeId = useScrollSpy(headings)
+const TableOfContents: React.FC<{ rootKey: string }> = ({ rootKey }) => {
+  const headings = useHeadings(rootKey)
+  const activeId = useScrollSpy(headings, rootKey)
   return (
     <ul className="flex list-none flex-col gap-2">
       {headings.map((heading) => {


### PR DESCRIPTION
### Motivation
- The right-hand table of contents occasionally showed headings from the About page after navigation because the TOC logic queried headings globally and did not scope to the current article instance.

### Description
- Add `data-toc-root={decodedSlug}` to the post `<article>` and pass `rootKey={decodedSlug}` into `<TableOfContents />` to bind a TOC to the current article instance (`src/components/posts/post-content.tsx`).
- Replace global heading collection with `findTocRoot` + `collectHeadings(rootKey)` so headings are only gathered from the matching article root (`src/components/posts/table-of-contents.tsx`).
- Update the scroll-spy (`useScrollSpy`) to locate and observe headings inside the found article root and to schedule `setActiveId` via `requestAnimationFrame` when empty to avoid synchronous setState-in-effect issues (`src/components/posts/table-of-contents.tsx`).
- Update hook signatures and component props to accept the `rootKey` parameter and wire the new scoping across the module (`src/components/posts/table-of-contents.tsx`, `src/components/posts/post-content.tsx`).

### Testing
- Ran `pnpm lint`, which completed and reported the existing warnings (no new errors introduced). 
- Ran `pnpm build`, which failed in this environment because `next/font` could not fetch Google Fonts (so build errors are environmental and unrelated to the TOC changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea0a517d0832c809c9ed41e4b48ef)